### PR TITLE
feat: 채팅방 입장 시 현재 로그인한 User의 DB에 chatid 값 업데이트 & Users DB에서 해당 채팅방에 참여하는 모든 사람 정보 return 기능 개발

### DIFF
--- a/src/main/java/com/example/cinderella/config/auth/SecurityConfig.java
+++ b/src/main/java/com/example/cinderella/config/auth/SecurityConfig.java
@@ -26,7 +26,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .logoutSuccessUrl("/login")
                 .and()
                 .oauth2Login()
-                .defaultSuccessUrl("/main", true)
+                .defaultSuccessUrl("/chatroom/1", true)
+                .failureUrl("/chat/test")
                 .userInfoEndpoint()
                 .userService(customOAuth2UserService);
     }

--- a/src/main/java/com/example/cinderella/config/auth/SecurityConfig.java
+++ b/src/main/java/com/example/cinderella/config/auth/SecurityConfig.java
@@ -26,8 +26,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .logoutSuccessUrl("/login")
                 .and()
                 .oauth2Login()
-                .defaultSuccessUrl("/chatroom/1", true)
-                .failureUrl("/chat/test")
+                .defaultSuccessUrl("/success", true)
+                .failureUrl("/fail")
                 .userInfoEndpoint()
                 .userService(customOAuth2UserService);
     }

--- a/src/main/java/com/example/cinderella/domain/chat/Chat.java
+++ b/src/main/java/com/example/cinderella/domain/chat/Chat.java
@@ -34,10 +34,8 @@ public class Chat extends BaseTimeEntity {
         this.num_of_people = num_of_people;
     }
 
-//    public void update(String host, String start, String dest) {
-//        this.host = host;
-//        this.start = start;
-//        this.dest = dest;
-//    }
+    public void update() {
+        this.num_of_people++;
+    }
 
 }

--- a/src/main/java/com/example/cinderella/domain/chat/ChatRepository.java
+++ b/src/main/java/com/example/cinderella/domain/chat/ChatRepository.java
@@ -1,9 +1,12 @@
 package com.example.cinderella.domain.chat;
 
+import com.example.cinderella.domain.user.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatRepository extends JpaRepository<Chat, Long> {
     List<Chat> findAllByStart(String start);
+    Optional<Chat> findByChatid(Long chatid);
 }

--- a/src/main/java/com/example/cinderella/domain/user/Users.java
+++ b/src/main/java/com/example/cinderella/domain/user/Users.java
@@ -25,8 +25,11 @@ public class Users extends BaseTimeEntity {
     @Column(nullable = false)
     private Role role;
 
+    @Column
+    private Long chatid;
+
     @Builder
-    public Users(String name, String email, Role role, String title) {
+    public Users(String name, String email, Role role) {
         this.name = name;
         this.email = email;
         this.role = role;
@@ -34,7 +37,11 @@ public class Users extends BaseTimeEntity {
 
     public Users update(String name) {
         this.name = name;
+        return this;
+    }
 
+    public Users updateChatid(Long chatid) {
+        this.chatid = chatid;
         return this;
     }
 

--- a/src/main/java/com/example/cinderella/domain/user/UsersRepository.java
+++ b/src/main/java/com/example/cinderella/domain/user/UsersRepository.java
@@ -1,9 +1,14 @@
 package com.example.cinderella.domain.user;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UsersRepository extends JpaRepository<Users, Long> {
     Optional<Users> findByEmail(String email);
+    @Modifying(clearAutomatically = true)
+    List<Users> findAllByChatid(Long chatid);
+
 }

--- a/src/main/java/com/example/cinderella/service/ChatroomService.java
+++ b/src/main/java/com/example/cinderella/service/ChatroomService.java
@@ -1,0 +1,44 @@
+package com.example.cinderella.service;
+
+import com.example.cinderella.domain.chat.Chat;
+import com.example.cinderella.domain.chat.ChatRepository;
+import com.example.cinderella.domain.user.Role;
+import com.example.cinderella.web.dto.UsersResponseDto;
+import com.example.cinderella.domain.user.Users;
+import com.example.cinderella.domain.user.UsersRepository;
+import com.example.cinderella.web.dto.UsersSaveRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class ChatroomService {
+    private final UsersRepository usersRepository;
+    private final ChatRepository chatRepository;
+    @Transactional(readOnly = true)
+    public List<UsersResponseDto> findAllByChatid(Long chatid) {
+        List<Users> entity = usersRepository.findAllByChatid(chatid);
+        return entity.stream()
+                .map(UsersResponseDto::new)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void updateChatid(String email, Long chatid) {
+        Users users = usersRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("해당 이메일의 정보가 없습니다. email=" + email));
+        users.updateChatid(chatid);
+    }
+
+    @Transactional
+    public void updateNumofpeople(Long chatid) {
+        Chat chat = chatRepository.findByChatid(chatid)
+                .orElseThrow(() -> new IllegalArgumentException("해당 Chat id의 정보가 없습니다. chatid=" + chatid));
+        chat.update();
+    }
+
+}

--- a/src/main/java/com/example/cinderella/web/ChatroomController.java
+++ b/src/main/java/com/example/cinderella/web/ChatroomController.java
@@ -1,0 +1,27 @@
+package com.example.cinderella.web;
+
+import com.example.cinderella.web.dto.UsersResponseDto;
+import com.example.cinderella.service.ChatroomService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpSession;
+import java.util.List;
+@RequiredArgsConstructor
+@RestController
+public class ChatroomController {
+    private final ChatroomService chatroomService;
+
+    @GetMapping("/chatroom/{chatid}")
+    public List<UsersResponseDto> findChatroom(@PathVariable Long chatid, Authentication authentication) {
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        chatroomService.updateNumofpeople(chatid);
+        chatroomService.updateChatid(oAuth2User.getAttribute("email"), chatid);
+        List<UsersResponseDto> users = chatroomService.findAllByChatid(chatid);
+        return users;
+    }
+}

--- a/src/main/java/com/example/cinderella/web/dto/ChatResponseDto.java
+++ b/src/main/java/com/example/cinderella/web/dto/ChatResponseDto.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 
 @Getter
 public class ChatResponseDto {
+
+    private Long id;
     private String host;
     private String start;
     private String dest;
@@ -12,6 +14,7 @@ public class ChatResponseDto {
     private int num_of_people;
 
     public ChatResponseDto(Chat entity) {
+        this.id = entity.getId();
         this.host = entity.getHost();
         this.start = entity.getStart();
         this.dest = entity.getDest();

--- a/src/main/java/com/example/cinderella/web/dto/UsersResponseDto.java
+++ b/src/main/java/com/example/cinderella/web/dto/UsersResponseDto.java
@@ -1,0 +1,18 @@
+package com.example.cinderella.web.dto;
+
+import com.example.cinderella.domain.user.Users;
+import lombok.Getter;
+
+@Getter
+public class UsersResponseDto {
+
+    private Long id;
+    private String name;
+    private Long chatid;
+
+    public UsersResponseDto(Users entity) {
+        this.id = entity.getId();
+        this.name = entity.getName();
+        this.chatid = entity.getChatid();
+    }
+}

--- a/src/main/java/com/example/cinderella/web/dto/UsersSaveRequestDto.java
+++ b/src/main/java/com/example/cinderella/web/dto/UsersSaveRequestDto.java
@@ -1,0 +1,31 @@
+package com.example.cinderella.web.dto;
+
+import com.example.cinderella.domain.chat.Chat;
+import com.example.cinderella.domain.user.Role;
+import com.example.cinderella.domain.user.Users;
+
+import javax.persistence.Column;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+public class UsersSaveRequestDto {
+
+    private String name;
+
+    private String email;
+
+    private Role role;
+
+    public UsersSaveRequestDto(String name, String email) {
+        this.name = name;
+        this.email = email;
+        this.role = Role.USER;
+    }
+    public Users toEntity() {
+        return Users.builder()
+                .name(name)
+                .email(email)
+                .role(role)
+                .build();
+    }
+}


### PR DESCRIPTION
# 변경점 👍
채팅방 입장 시 현재 로그인한 User의 DB에 chatid 값 업데이트
Users DB에서 해당 채팅방에 참여하는 모든 사람 정보 return
현재 참여한 채팅방의 chat DB에서 참여자 수 업데이트
 
# 스크린샷 🖼
컨트롤러
![image](https://github.com/Apptive2022-1/apptive-18th-cinderella-backend/assets/99969990/edb3d894-f928-4008-ab7a-8f908e7eb165)
 
chatid를 통해 user DB를 찾는 findAllByChatid, 현재 로그인된 유저의 DB 정보에 chatid 값을 변경해주는 updateChatid, 현재 채팅방의 참여 인원을 변경해주는 updateNumofpeople
![image](https://github.com/Apptive2022-1/apptive-18th-cinderella-backend/assets/99969990/a482f2e5-2218-459b-9e0a-2904d7946d8f)
